### PR TITLE
Add new feather for arg --ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ If you enter -s argument, this tool checks both http:// and https://
 When the link starts with https://, this tool checks whether the link is broken or not if it changes to http://.
 <br/>Also, when the link starts with http://, this tool checks whether the lilnk is broken or not if the changes to https://.
 
+### ignore URL pattern(s) using a text file (Argument -s)
+For example, if you write 'https://www.google.com" in the text file (ignore-urls.txt), then run the command $ tool-name --ignore ignore-urls.txt index.html. Your tool will check all URLs in index.html, but ignore the URLs in ignore-url.txt which is "https://www.google.com" in this case.
+
 ### Helping option
 When you enter -h argument, this tool prints out the usage of this tool.
 

--- a/ignore.txt
+++ b/ignore.txt
@@ -1,0 +1,15 @@
+<a
+    href="https://wiki.cdot.senecacollege.ca/w/api.php?action=rsd">https://wiki.cdot.senecacollege.ca/w/api.php?action=rsd</a>
+<a href="http://zenit.senecac.on.ca/~chris.tyler/planet/">http://zenit.senecac.on.ca/~chris.tyler/planet/</a>
+<a href="http://www.wordpress.com">http://www.wordpress.com</a>
+<a href="http://en.wikipedia.org/wiki/RSS_(file_format)">http://en.wikipedia.org/wiki/RSS_(file_format)</a>
+<a href="http://en.wikipedia.org/wiki/RSS_(file_format)">http://en.wikipedia.org/wiki/RSS_(file_format)</a>
+<a href="http://en.wikipedia.org/wiki/Hackergotchi">http://en.wikipedia.org/wiki/Hackergotchi</a>
+<a href="http://s-aleinikov.blog.ca/feed/atom/posts/">http://s-aleinikov.blog.ca/feed/atom/posts/</a>
+<a href="http://ejtorre.blog.ca/feed/rss2/posts/">http://ejtorre.blog.ca/feed/rss2/posts/</a>
+<a href="http://rickeyre.ca/open-source-feed.xml">http://rickeyre.ca/open-source-feed.xml</a>
+<a
+    href="http://tea.cesaroliveira.net/archives/tag/seneca/feed">http://tea.cesaroliveira.net/archives/tag/seneca/feed</a>
+<a href="http://blog.marcussaad.com/?feed=rss2&amp;lang=en">http://blog.marcussaad.com/?feed=rss2&amp;lang=en</a>
+<a href="http://matthewtorrance.com/category/osd/feed/">http://matthewtorrance.com/category/osd/feed/</a>
+<a href="http://hesam-chobanlou.com/feed/atom.php">http://hesam-chobanlou.com/feed/atom.php</a>

--- a/ignore.txt
+++ b/ignore.txt
@@ -1,2 +1,1 @@
-#http://s9y.org http://s9y.org
-http://s9y.org
+   # http://s9y.org 

--- a/ignore.txt
+++ b/ignore.txt
@@ -1,15 +1,2 @@
-<a
-    href="https://wiki.cdot.senecacollege.ca/w/api.php?action=rsd">https://wiki.cdot.senecacollege.ca/w/api.php?action=rsd</a>
-<a href="http://zenit.senecac.on.ca/~chris.tyler/planet/">http://zenit.senecac.on.ca/~chris.tyler/planet/</a>
-<a href="http://www.wordpress.com">http://www.wordpress.com</a>
-<a href="http://en.wikipedia.org/wiki/RSS_(file_format)">http://en.wikipedia.org/wiki/RSS_(file_format)</a>
-<a href="http://en.wikipedia.org/wiki/RSS_(file_format)">http://en.wikipedia.org/wiki/RSS_(file_format)</a>
-<a href="http://en.wikipedia.org/wiki/Hackergotchi">http://en.wikipedia.org/wiki/Hackergotchi</a>
-<a href="http://s-aleinikov.blog.ca/feed/atom/posts/">http://s-aleinikov.blog.ca/feed/atom/posts/</a>
-<a href="http://ejtorre.blog.ca/feed/rss2/posts/">http://ejtorre.blog.ca/feed/rss2/posts/</a>
-<a href="http://rickeyre.ca/open-source-feed.xml">http://rickeyre.ca/open-source-feed.xml</a>
-<a
-    href="http://tea.cesaroliveira.net/archives/tag/seneca/feed">http://tea.cesaroliveira.net/archives/tag/seneca/feed</a>
-<a href="http://blog.marcussaad.com/?feed=rss2&amp;lang=en">http://blog.marcussaad.com/?feed=rss2&amp;lang=en</a>
-<a href="http://matthewtorrance.com/category/osd/feed/">http://matthewtorrance.com/category/osd/feed/</a>
-<a href="http://hesam-chobanlou.com/feed/atom.php">http://hesam-chobanlou.com/feed/atom.php</a>
+#http://s9y.org http://s9y.org
+http://s9y.org

--- a/index.js
+++ b/index.js
@@ -68,7 +68,14 @@ for (let i = 2; i < process.argv.length; i++) {
     if (ignore) {
         arg = process.argv[++i];
         data = fs.readFileSync(arg, 'utf8');
-        ignoredLink = data.toString().match(linkRegex);
+        array = data.split("\n");
+        string = "";
+        for(let i = 0; i < array.length; i++){
+            if(!array[i].startsWith("#")){
+                string += array[i];
+            }
+        }
+        ignoredLink = string.match(linkRegex);
         if (ignoredLink == null){
             console.log(colors.red("The ignore file is invalid.  It doesn't use http:// or https://"));
             process.exitCode = 1;
@@ -89,9 +96,7 @@ for (let i = 2; i < process.argv.length; i++) {
             }
             let links = data.match(linkRegex);
             //ignore the links
-            links = links.filter(function(url){
-                return ignoredLink.indexOf(url) == -1;
-            })
+            links = links.filter(val => !ignoredLink.includes(val));
             for (let i = 0; i < links.length; i++) {
                 let link = links[i];
                 if (link.startsWith("https://")) {

--- a/index.js
+++ b/index.js
@@ -71,7 +71,8 @@ for (let i = 2; i < process.argv.length; i++) {
         array = data.split("\n");
         string = "";
         for(let i = 0; i < array.length; i++){
-            if(!array[i].startsWith("#")){
+
+            if(!array[i].trim().startsWith("#")){
                 string += array[i];
             }
         }

--- a/index.js
+++ b/index.js
@@ -67,19 +67,13 @@ for (let i = 2; i < process.argv.length; i++) {
     let arg = process.argv[i];
     if (ignore) {
         arg = process.argv[++i];
-        fs.readFile(path.normalize(arg), 'utf8', function (err, data) {
-            if (err) {
-                console.log(colors.red(err));
-                process.exitCode = 1;
-                process.exit(1);
-            }
-            ignoredLink = data.match(linkRegex);
-            if (ignoredLink == null){
-                console.log(colors.red("The ignore file is invalid.  It doesn't use http:// or https://"));
-                process.exitCode = 1;
-                process.exit(1);
-            } 
-        })
+        data = fs.readFileSync(arg, 'utf8');
+        ignoredLink = data.toString().match(linkRegex);
+        if (ignoredLink == null){
+            console.log(colors.red("The ignore file is invalid.  It doesn't use http:// or https://"));
+            process.exitCode = 1;
+            process.exit(1);
+        } 
         ignore = false; 
         i++;
     }


### PR DESCRIPTION
Added the feather discussed in  [issue#12](https://github.com/hyunjiLeeTech/URL-FI/issues/12). 
The test result shows below:
Ignore.txt contains all the URLs that test.txt have except the "s9y.org". The result will print only "s9y.org"
![IGNORE1](https://user-images.githubusercontent.com/60892464/96304866-e681aa80-0fca-11eb-9690-0d2c1ca95a01.jpg)
Updated the README file for new arguments.
Please let me know if I did anything incorrectly, thanks!
