### PR TITLE
Updated readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 This is a command-line tool for finding and reporting dead links (e.g., broken URLs) in a file. Users might use this tool to help locate broken URLs in an HTML page, text file, and so on. This tool can handle multiple files at the same time.
 
 ## How to Set up the Tool
-1. Copy and paste the link into a terminal or visual studio code with the following command: git clone https://github.com/hyunjiLeeTech/URL-FI.git
-2. To start the tool use the cd command to make sure you are in the correct folder and then install all the dependencies using the npm command: npm i 
-3. Enter the command to start the tool. You need to mention the file name.
+1. Copy and paste the link into a terminal or visual studio code with the following command: `git clone https://github.com/hyunjiLeeTech/URL-FI.git`
+2. Use the cd command to make sure you are in the correct folder and then install all the dependencies using the npm command: `npm i`
+3. Make a symbolic link of the command using `npm link`
+4. Enter the command along with a filename to use the tool.
 
 ## Synopsis
 url-fi [OPTION] [FILENAME]


### PR DESCRIPTION
The set up instructions don't mention 'npm link' which doesn't let you use the command globally. You can only use node index.js ... to use the tool. I have added "npm link" to the readme.md file now.